### PR TITLE
Add data XLSXFile.init, remove filepath property

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.formatOnSave": true,
+  "editor.detectIndentation": false,
+  "editor.tabSize": 2,
+  "licenser.author": "CoreOffice contributors"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "swift test",
+      "type": "shell",
+      "command": "./test_swiftpm.sh",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-Copyright 2018-2019 Max Desiatov
+Copyright 2018-2020 CoreOffice contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/CoreXLSX/Comments.swift
+++ b/Sources/CoreXLSX/Comments.swift
@@ -1,7 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Comments.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 public struct Comments: Codable, Equatable {
   public let commentList: CommentList

--- a/Sources/CoreXLSX/Path.swift
+++ b/Sources/CoreXLSX/Path.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  File.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 19/02/2019.
 //

--- a/Sources/CoreXLSX/Relationships.swift
+++ b/Sources/CoreXLSX/Relationships.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Relationships.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 27/10/2018.
 //

--- a/Sources/CoreXLSX/SharedStrings.swift
+++ b/Sources/CoreXLSX/SharedStrings.swift
@@ -1,11 +1,20 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  SharedStrings.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 18/11/2018.
 //
 
-// swiftlint:disable line_length
 /// Attributes and nodes are documented in [Microsoft
 /// docs](https://docs.microsoft.com/en-us/office/open-xml/working-with-the-shared-string-table)
 public struct SharedStrings: Codable, Equatable {

--- a/Sources/CoreXLSX/Styles.swift
+++ b/Sources/CoreXLSX/Styles.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Styles.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 16/03/2019.
 //

--- a/Sources/CoreXLSX/Workbook.swift
+++ b/Sources/CoreXLSX/Workbook.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Workbook.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 23/11/2018.
 //

--- a/Sources/CoreXLSX/Worksheet/Cell.swift
+++ b/Sources/CoreXLSX/Worksheet/Cell.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Cell.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 24/11/2018.
 //

--- a/Sources/CoreXLSX/Worksheet/CellQueries.swift
+++ b/Sources/CoreXLSX/Worksheet/CellQueries.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  CellQueries.swift
-//  CoreXLSXmacOS
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 24/11/2018.
 //

--- a/Sources/CoreXLSX/Worksheet/CellReference.swift
+++ b/Sources/CoreXLSX/Worksheet/CellReference.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  CellReference.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 14/11/2018.
 //

--- a/Sources/CoreXLSX/Worksheet/ColumnReference.swift
+++ b/Sources/CoreXLSX/Worksheet/ColumnReference.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Reference.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 13/11/2018.
 //

--- a/Sources/CoreXLSX/Worksheet/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet/Worksheet.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Worksheet.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 31/10/2018.
 //

--- a/Tests/CoreXLSXTests/Border.swift
+++ b/Tests/CoreXLSXTests/Border.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Border.swift
-//  CoreXLSXTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 24/05/2019.
 //

--- a/Tests/CoreXLSXTests/CellReference.swift
+++ b/Tests/CoreXLSXTests/CellReference.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  CellReference.swift
-//  CoreXLSXTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 15/11/2018.
 //

--- a/Tests/CoreXLSXTests/Comments.swift
+++ b/Tests/CoreXLSXTests/Comments.swift
@@ -1,7 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Comments.swift
-//  CoreXLSXTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 @testable import CoreXLSX
 import XCTest

--- a/Tests/CoreXLSXTests/Formula.swift
+++ b/Tests/CoreXLSXTests/Formula.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Formula.swift
-//  CoreXLSXTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 02/05/2019.
 //

--- a/Tests/CoreXLSXTests/Namespaces.swift
+++ b/Tests/CoreXLSXTests/Namespaces.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Namespaces.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 11/04/2019.
 //

--- a/Tests/CoreXLSXTests/Relationships.swift
+++ b/Tests/CoreXLSXTests/Relationships.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Relationships.swift
-//  CoreXLSXTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 15/11/2018.
 //

--- a/Tests/CoreXLSXTests/SharedStrings.swift
+++ b/Tests/CoreXLSXTests/SharedStrings.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  SharedStrings.swift
-//  CoreXLSXTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 30/11/2018.
 //

--- a/Tests/CoreXLSXTests/Styles.swift
+++ b/Tests/CoreXLSXTests/Styles.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Styles.swift
-//  CoreXLSX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 16/03/2019.
 //

--- a/Tests/CoreXLSXTests/Workbook.swift
+++ b/Tests/CoreXLSXTests/Workbook.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Workbook.swift
-//  CoreXLSXTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 23/11/2018.
 //

--- a/Tests/CoreXLSXTests/Worksheet.swift
+++ b/Tests/CoreXLSXTests/Worksheet.swift
@@ -1,6 +1,16 @@
+// Copyright 2019-2020 CoreOffice contributors
 //
-//  Worksheet.swift
-//  CoreXLSXTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  Created by Max Desiatov on 24/11/2018.
 //


### PR DESCRIPTION
With the new `Data` initializer on `XLSXFile` the `filepath` property no longer makes sense. It also wasn't used anywhere internally.