### PR TITLE
Add “person” to the relationship types

### DIFF
--- a/Sources/CoreXLSX/Relationships.swift
+++ b/Sources/CoreXLSX/Relationships.swift
@@ -105,6 +105,11 @@ public struct Relationship: Codable, Equatable {
       http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
       customXml
       """
+    case person =
+      """
+      http://schemas.microsoft.com/office/2017/10/relationships/\
+      person
+      """
   }
 
   public let id: String

--- a/Tests/CoreXLSXTests/Relationships.swift
+++ b/Tests/CoreXLSXTests/Relationships.swift
@@ -43,6 +43,19 @@ Target="xl/workbook.xml"/>
 </Relationships>
 """.data(using: .utf8)!
 
+let personXML = """
+<Relationships
+xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+
+<Relationship
+Id="rId4"
+Type="http://schemas.microsoft.com/office/2017/10/relationships/\
+person"
+Target="xl/workbook.xml"/>
+
+</Relationships>
+""".data(using: .utf8)!
+
 private let parsed = [
   Relationship(id: "rId1",
                type: .packageCoreProperties,
@@ -52,8 +65,13 @@ private let parsed = [
                target: "docProps/app.xml"),
   Relationship(id: "rId3",
                type: .officeDocument,
-               target: "xl/workbook.xml"),
+               target: "xl/workbook.xml")
 ]
+
+private let person =
+    Relationship(id: "rId4",
+             type: .person,
+             target: "xl/workbook.xml")
 
 final class RelationshipsTests: XCTestCase {
   func testRelationships() throws {
@@ -72,6 +90,14 @@ final class RelationshipsTests: XCTestCase {
     let relationshipsFromFile = try file.parseRelationships()
 
     XCTAssertEqual(relationshipsFromFile, Relationships(items: parsed))
+  }
+    
+  func testPersonRelationship() throws {
+    let decoder = XMLDecoder()
+    decoder.keyDecodingStrategy = .convertFromCapitalized
+    let relationships = try decoder.decode(Relationships.self,
+                                           from: personXML)
+    XCTAssertEqual(relationships.items, [person])
   }
 
   func testCustomXmlSchemaType() throws {


### PR DESCRIPTION
I tried to parse a spreadsheet, it failed with:
```
Cannot initialize SchemaType from invalid String value http://schemas.microsoft.com/office/2017/10/relationships/person
```

I added the case and it fixed my issue locally.
I added a test. I will change it up however you want, but I can't include the original spreadsheet, sorry.